### PR TITLE
Move GDPR consent metadata to before Unity Ads initialize

### DIFF
--- a/UnityAds/UnityRouter.m
+++ b/UnityAds/UnityRouter.m
@@ -55,6 +55,7 @@
 
 - (void)initializeWithGameId:(NSString *)gameId
 {
+    [self setIfUnityAdsCollectsPersonalInfo];
     static dispatch_once_t unityInitToken;
     dispatch_once(&unityInitToken, ^{
         UADSMediationMetaData *mediationMetaData = [[UADSMediationMetaData alloc] init];
@@ -65,7 +66,6 @@
         
         [UnityAds initialize:gameId delegate:self testMode:false enablePerPlacementLoad:true];
     });
-    [self setIfUnityAdsCollectsPersonalInfo];
 }
 
 - (void) setIfUnityAdsCollectsPersonalInfo


### PR DESCRIPTION
GDPR is currently being set after init, which makes the GDPR consent flow show up in Unity Ads even when Mopub sets consent manually

https://jira.hq.unity3d.com/browse/ABT-946